### PR TITLE
C[] 与 W[] 误用。

### DIFF
--- a/pack.lyx
+++ b/pack.lyx
@@ -765,7 +765,7 @@ for
 \end_inset
 
  to 
-\begin_inset Formula $\mathrm{max}(V-\Sigma_{i}^{N}W_{i},C_{i})$
+\begin_inset Formula $\mathrm{max}(V-\Sigma_{i}^{N}C_{i},C_{i})$
 \end_inset
 
 


### PR DESCRIPTION
详见我对pack V01的上一个push。
量纲错误。